### PR TITLE
fix: handle exceptions in Program.Main to prevent printing StackTrace…

### DIFF
--- a/src/CommitLint.Net/Program.cs
+++ b/src/CommitLint.Net/Program.cs
@@ -12,15 +12,28 @@ public class Program
             .Default.ParseArguments<Options>(args)
             .WithParsed(o =>
             {
-                var configFileName = o.CommitMessageConfigFileName;
-                if (string.IsNullOrWhiteSpace(configFileName))
+                try
                 {
-                    Console.WriteLine("No config file provided. Using default config.");
-                    configFileName = GetDefaultConfig();
-                }
+                    var configFileName = o.CommitMessageConfigFileName;
+                    if (string.IsNullOrWhiteSpace(configFileName))
+                    {
+                        Console.WriteLine("No config file provided. Using default config.");
+                        configFileName = GetDefaultConfig();
+                    }
 
-                var linterConfig = new LinterConfig(o.CommitMessageFileName, configFileName);
-                new Linter().Run(linterConfig);
+                    var linterConfig = new LinterConfig(o.CommitMessageFileName, configFileName);
+                    var linter = new Linter();
+                    linter.Run(linterConfig);
+                }
+                catch (CommitFormatException ex)
+                {
+                    Console.WriteLine(ex.Message);
+                    exitCode = 1;
+                }
+                catch (Exception)
+                {
+                    exitCode = 1;
+                }
             })
             .WithNotParsed(errors =>
             {


### PR DESCRIPTION
… to console

- CommitFormatException is handled and only its custom message is printed - program exits with exit code 1
- Other exception types are handled, nothing is printed to console and program exits with exit code 1

Partially-resolving #6 - resolves issue with printing StackTrace to console output
(Changed footer token wording a bit to not close issue yet as there is still a feature to implement)