### PR TITLE
feat: added verbosity option for log levels

### DIFF
--- a/src/CommitLint.Net/Linter.cs
+++ b/src/CommitLint.Net/Linter.cs
@@ -1,3 +1,4 @@
+using CommitLint.Net.Logging;
 using CommitLint.Net.Validators;
 
 namespace CommitLint.Net;
@@ -21,12 +22,12 @@ public sealed class Linter
 
     private static void PrintCommit(string[] commitMessage)
     {
-        Console.WriteLine("Commit message with line numbers:");
+        Log.Verbose("Commit message with line numbers:");
         for (int i = 0; i < commitMessage.Length; ++i)
         {
-            Console.WriteLine($"    {i}: {commitMessage[i]}");
+            Log.Verbose($"    {i}: {commitMessage[i]}");
         }
 
-        Console.WriteLine();
+        Log.Verbose(Environment.NewLine);
     }
 }

--- a/src/CommitLint.Net/Logging/Log.cs
+++ b/src/CommitLint.Net/Logging/Log.cs
@@ -1,0 +1,36 @@
+namespace CommitLint.Net.Logging;
+
+public static class Log
+{
+    public static LogLevel MinLogLevel { get; set; } = LogLevel.Info;
+
+    public static void Error(string message)
+    {
+        LogInternal(message, LogLevel.Error);
+    }
+
+    public static void Info(string message)
+    {
+        LogInternal(message, LogLevel.Info);
+    }
+
+    public static void Verbose(string message)
+    {
+        LogInternal(message, LogLevel.Verbose);
+    }
+
+    private static void LogInternal(string message, LogLevel logLevel)
+    {
+        if (logLevel > MinLogLevel)
+            return;
+
+        Console.WriteLine(message);
+    }
+
+    public enum LogLevel
+    {
+        Error,
+        Info,
+        Verbose,
+    }
+}

--- a/src/CommitLint.Net/Options.cs
+++ b/src/CommitLint.Net/Options.cs
@@ -19,4 +19,13 @@ public class Options
         HelpText = "Provide file name of commit message config in json format."
     )]
     public string? CommitMessageConfigFileName { get; set; } = null!;
+
+    [Option(
+        'v',
+        "verbosity",
+        Required = false,
+        Default = "info",
+        HelpText = "Set the log verbosity level: error, info, verbose"
+    )]
+    public string? Verbosity { get; set; }
 }

--- a/src/CommitLint.Net/Program.cs
+++ b/src/CommitLint.Net/Program.cs
@@ -1,4 +1,5 @@
 using CommandLine;
+using CommitLint.Net.Logging;
 
 namespace CommitLint.Net;
 
@@ -17,7 +18,7 @@ public class Program
                     var configFileName = o.CommitMessageConfigFileName;
                     if (string.IsNullOrWhiteSpace(configFileName))
                     {
-                        Console.WriteLine("No config file provided. Using default config.");
+                        Log.Info("No config file provided. Using default config.");
                         configFileName = GetDefaultConfig();
                     }
 
@@ -27,11 +28,12 @@ public class Program
                 }
                 catch (CommitFormatException ex)
                 {
-                    Console.WriteLine(ex.Message);
+                    Log.Error(ex.Message);
                     exitCode = 1;
                 }
                 catch (Exception)
                 {
+                    Log.Error("Unknown error.");
                     exitCode = 1;
                 }
             })

--- a/src/CommitLint.Net/Program.cs
+++ b/src/CommitLint.Net/Program.cs
@@ -15,6 +15,12 @@ public class Program
             {
                 try
                 {
+                    exitCode = SetupLogLevel(o);
+                    if (exitCode == 1)
+                    {
+                        return;
+                    }
+
                     var configFileName = o.CommitMessageConfigFileName;
                     if (string.IsNullOrWhiteSpace(configFileName))
                     {
@@ -41,6 +47,32 @@ public class Program
             {
                 exitCode = 1;
             });
+
+        return exitCode;
+    }
+
+    private static int SetupLogLevel(Options o)
+    {
+        var exitCode = 0;
+        if (o.Verbosity is null)
+            return exitCode;
+
+        if (Enum.TryParse(typeof(Log.LogLevel), o.Verbosity, true, out var result))
+        {
+            Log.MinLogLevel = (Log.LogLevel)result;
+        }
+        else
+        {
+            exitCode = 1;
+            var helpText = typeof(Options)
+                .GetProperty(nameof(Options.Verbosity))
+                ?.GetCustomAttributes(typeof(OptionAttribute), false)
+                .OfType<OptionAttribute>()
+                .FirstOrDefault()
+                ?.HelpText;
+
+            Log.Error($"Verbosity option was used with unsupported value. Usage: {helpText}");
+        }
 
         return exitCode;
     }

--- a/src/CommitLint.Net/Rules/Models/Rule.cs
+++ b/src/CommitLint.Net/Rules/Models/Rule.cs
@@ -1,3 +1,5 @@
+using CommitLint.Net.Logging;
+
 namespace CommitLint.Net.Rules.Models;
 
 public abstract class Rule<T>(T? config) : IRule
@@ -14,36 +16,31 @@ public abstract class Rule<T>(T? config) : IRule
         LogStart();
         if (Config is null)
         {
-            Log("Configuration value not found. Not validating.");
+            Log.Info("\tConfiguration value not found. Not validating.");
             return RuleValidationResult.ConfigNull();
         }
 
         if (!IsEnabled)
         {
-            Log("Check disabled");
+            Log.Info("\tCheck disabled");
             return RuleValidationResult.Disabled();
         }
 
-        Log("Check enabled");
+        Log.Verbose("\tCheck enabled");
         var result = IsValidInternal(commitMessageLines);
         var message = result.IsValid ? $"Check passed {Checkmark}" : $"Check failed {Cross}";
         if (!string.IsNullOrEmpty(result.Message))
         {
             message += $" - {result.Message}";
         }
-        Log(message);
+        Log.Info($"\t{message}");
         return result;
     }
 
     protected abstract RuleValidationResult IsValidInternal(string[] commitMessageLines);
 
-    private void Log(string message)
-    {
-        Console.WriteLine($"\t{message}");
-    }
-
     private void LogStart()
     {
-        Console.WriteLine($"Rule {Name}");
+        Log.Info($"Rule {Name}");
     }
 }

--- a/tests/CommitLint.Net.Tests/IntegrationTests/ProgramTests.cs
+++ b/tests/CommitLint.Net.Tests/IntegrationTests/ProgramTests.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using CommitLint.Net.Logging;
 using FluentAssertions;
 
 namespace CommitLint.Net.Tests.IntegrationTests;
@@ -178,5 +179,45 @@ public class ProgramTests
             .NotContain("exception")
             .And.NotContain("   at ")
             .And.NotContain(":line ");
+    }
+
+    [Test]
+    public void WhenMainIsCalledWithVerbosityOption_ThenLogLevelIsUpdated(
+        [Values] Log.LogLevel logLevel
+    )
+    {
+        // Arrange
+        string[] args =
+        [
+            "--commit-file",
+            "IntegrationTests/Data/sampleCommit.txt",
+            "--verbosity",
+            logLevel.ToString().ToLower(),
+        ];
+
+        // Act
+        _ = Program.Main(args);
+
+        // Assert
+        Log.MinLogLevel.Should().Be(logLevel);
+    }
+
+    [Test]
+    public void WhenMainIsCalledWithUnsupportedVerbosity_ThenReturnOne()
+    {
+        // Arrange
+        string[] args =
+        [
+            "--commit-file",
+            "IntegrationTests/Data/sampleCommit.txt",
+            "--verbosity",
+            "wrong-verbosity",
+        ];
+
+        // Act
+        var result = Program.Main(args);
+
+        // Assert
+        result.Should().Be(1);
     }
 }

--- a/tests/CommitLint.Net.Tests/UnitTests/LoggingTests/LogTests.cs
+++ b/tests/CommitLint.Net.Tests/UnitTests/LoggingTests/LogTests.cs
@@ -1,0 +1,122 @@
+using System.Linq.Expressions;
+using CommitLint.Net.Logging;
+using FluentAssertions;
+
+namespace CommitLint.Net.Tests.UnitTests.LoggingTests;
+
+[TestFixture]
+public class LogTests
+{
+    private StringWriter _consoleOutput;
+    private TextWriter _originalConsoleOut;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _originalConsoleOut = Console.Out;
+        _consoleOutput = new StringWriter();
+        Console.SetOut(_consoleOutput);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Console.SetOut(_originalConsoleOut);
+        _consoleOutput.Dispose();
+    }
+
+    [TestCaseSource(nameof(LogLevelsEqualMinLogLevel))]
+    public void WhenMessageIsLoggedWithLogLevelEqualToMinLogLevel_ThenMessageIsLogged(
+        Log.LogLevel minLogLevel,
+        Expression<Action<string>> logAction,
+        string expectedMessage
+    )
+    {
+        // Arrange
+        Log.MinLogLevel = minLogLevel;
+        var action = logAction.Compile();
+
+        // Act
+        action(expectedMessage);
+
+        // Assert
+        _consoleOutput.ToString().Should().Be(expectedMessage + Environment.NewLine);
+    }
+
+    [TestCaseSource(nameof(LogLevelsAboveMinLogLevel))]
+    public void WhenMessageIsLoggedWithLogLevelAboveMinLogLevel_ThenMessageIsNotLogged(
+        Log.LogLevel minLogLevel,
+        Expression<Action<string>> logAction
+    )
+    {
+        // Arrange
+        Log.MinLogLevel = minLogLevel;
+        var action = logAction.Compile();
+
+        // Act
+        action("some message that should not be logged");
+
+        // Assert
+        _consoleOutput.ToString().Should().BeEmpty();
+    }
+
+    [TestCaseSource(nameof(LogLevelsBelowMinLogLevel))]
+    public void WhenMessageIsLoggedWithLogLevelBelowMinLogLevel_ThenMessageIsLogged(
+        Log.LogLevel minLogLevel,
+        Expression<Action<string>> logAction,
+        string expectedMessage
+    )
+    {
+        // Arrange
+        Log.MinLogLevel = minLogLevel;
+        var action = logAction.Compile();
+
+        // Act
+        action(expectedMessage);
+
+        // Assert
+        _consoleOutput.ToString().Should().Be(expectedMessage + Environment.NewLine);
+    }
+
+    private static IEnumerable<LogWithMessageTestCaseData> LogLevelsEqualMinLogLevel()
+    {
+        yield return new(Log.LogLevel.Error, message => Log.Error(message), "message1");
+        yield return new(Log.LogLevel.Info, message => Log.Info(message), "message2");
+        yield return new(Log.LogLevel.Verbose, message => Log.Verbose(message), "message3");
+    }
+
+    private static IEnumerable<LogTestCaseData> LogLevelsAboveMinLogLevel()
+    {
+        yield return new(Log.LogLevel.Error, message => Log.Info(message));
+        yield return new(Log.LogLevel.Error, message => Log.Verbose(message));
+        yield return new(Log.LogLevel.Info, message => Log.Verbose(message));
+    }
+
+    private static IEnumerable<LogWithMessageTestCaseData> LogLevelsBelowMinLogLevel()
+    {
+        yield return new(Log.LogLevel.Info, message => Log.Error(message), "message7");
+        yield return new(Log.LogLevel.Verbose, message => Log.Error(message), "message8");
+        yield return new(Log.LogLevel.Verbose, message => Log.Info(message), "message9");
+    }
+
+    private class LogWithMessageTestCaseData(
+        Log.LogLevel minLogLevel,
+        Expression<Action<string>> logAction,
+        string? expectedMessage = null
+    ) : TestCaseData(minLogLevel, logAction, expectedMessage)
+    {
+        public Log.LogLevel MinLogLevel { get; } = minLogLevel;
+        public Expression<Action<string>> LogAction { get; } = logAction;
+        public string? ExpectedMessage { get; } = expectedMessage;
+    }
+
+    private class LogTestCaseData(
+        Log.LogLevel minLogLevel,
+        Expression<Action<string>> logAction,
+        string? expectedMessage = null
+    ) : TestCaseData(minLogLevel, logAction)
+    {
+        public Log.LogLevel MinLogLevel { get; } = minLogLevel;
+        public Expression<Action<string>> LogAction { get; } = logAction;
+    }
+}


### PR DESCRIPTION
- Added a new command line option `--verbosity` to set log level to error, info, or verbose.
- Refactored logging by creating a static class `Log` to centralize logging functionality.
- Existing `Console.WriteLine` calls were updated to use the new `Log` class.